### PR TITLE
Rename project from 'portfolio-lovable' to 'portfolio'

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "portfolio-lovable",
+  "name": "portfolio",
   "compatibility_date": "2025-09-24",
   "compatibility_flags": ["nodejs_compat"],
   "main": "src/server.ts",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change; impact is limited to deployment/project naming in Cloudflare Wrangler.
> 
> **Overview**
> Renames the Cloudflare Wrangler project (`wrangler.jsonc` `name`) from `portfolio-lovable` to `portfolio`, affecting only the worker/project identifier used for deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466441c964971fb8a0ebf3bdbb187a8be1d6191e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->