### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,3 +120,21 @@ If a file you touched still has lint errors after autofix, fix them in the same 
 ### CI expectation
 
 Any CI added later MUST run, in order: `bun run format:check`, `bun run lint`, `bun run typecheck`, then build. Failing any step fails the build. Mirror lefthook so local and CI agree.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service         | Port | Command             | Notes                                                         |
+| --------------- | ---- | ------------------- | ------------------------------------------------------------- |
+| Vite dev server | 5173 | `bun run dev`       | Main app — TanStack Start SSR on Cloudflare Workers emulation |
+| Storybook       | 6006 | `bun run storybook` | Component sandbox (optional)                                  |
+
+### Gotchas
+
+- **Bun must be installed first.** The VM image ships Node but not Bun. The update script handles this — see `curl -fsSL https://bun.sh/install | bash`.
+- **lefthook install requires `--force`** in Cloud Agent VMs because Cursor sets `core.hooksPath` locally. Run `bunx lefthook install --force` instead of plain `bun run prepare`.
+- **`.env` is a generated file** (per Hard Rules) and must not be edited or committed. The repo ships `.env.example`; the real `.env` is pre-populated in the VM with Supabase credentials.
+- **Supabase is hosted** — no local Supabase CLI or Docker required. The app connects to the remote Supabase project via env vars.
+- **`bun run format:check` may fail on files you didn't touch** — run `bun run format` to auto-fix before committing.
+- The dev server emits a harmless `punycode` deprecation warning from Node — ignore it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with:

- Service table (Vite dev server on :5173, Storybook on :6006)
- Key gotchas for Cloud Agent VMs: Bun installation, lefthook `--force` flag, `.env` handling, hosted Supabase, format check behavior, harmless punycode warning

**Environment verified:**
- `bun run lint` — passes (2 warnings, 0 errors)
- `bun run typecheck` — passes
- `bun run dev` — Vite dev server on :5173, portfolio renders and contact form submits
- `bun run storybook` — Storybook on :6006 with all component stories

[portfolio-and-storybook-demo.mp4](https://cursor.com/agents/bc-3aaf242e-1034-4f15-ba39-b8cdb66d917d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio-and-storybook-demo.mp4)

[Portfolio homepage](https://cursor.com/agents/bc-3aaf242e-1034-4f15-ba39-b8cdb66d917d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio-homepage.webp)
[Storybook running](https://cursor.com/agents/bc-3aaf242e-1034-4f15-ba39-b8cdb66d917d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook-running.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3aaf242e-1034-4f15-ba39-b8cdb66d917d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3aaf242e-1034-4f15-ba39-b8cdb66d917d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

