### PR TITLE
Little cleanup

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,8 +1,0 @@
-{
-  "editor.defaultFormatter": "oxc.oxc-vscode",
-  "editor.formatOnSave": false, // disable default behavior
-  "editor.codeActionsOnSave": {
-    "source.format.oxc": "always", // run formatter first
-    "source.fixAll.oxc": "always" // run lint fixes after
-  }
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Conventions for AI agents (and humans) working in this repo. Keep this file shor
 - **NEVER** downgrade TypeScript below 6.x or remove the `@codecompose/typescript-config` extends.
 - **NEVER** stage or commit `storybook-static/` — it's Storybook's minified build output. Stays in `.gitignore` and in `ignorePatterns` for both `.oxlintrc.json` / `.oxfmtrc.json`; staging it floods oxlint with thousands of false positives on chunk bundles.
 - **NEVER** commit placeholder action refs (for example TODO markers, incomplete SHAs, or temporary values). For CI/tooling changes, preserve the last-known-good working ref unless the replacement is verified.
+- **NEVER** create `.cursor/settings.json` — Cursor is a VS Code fork and reads workspace editor settings from `.vscode/settings.json` only. The `.cursor/` directory is reserved for things Cursor actually consumes (`rules/`, `mcp.json`, `environment.json`, `sandbox.json`); a `.cursor/settings.json` is silently ignored and just shadow-confuses readers vs. the real `.vscode` values.
 
 ## Scripts (use these — don't invent new ones)
 
@@ -33,6 +34,11 @@ Conventions for AI agents (and humans) working in this repo. Keep this file shor
 | Install hooks        | `bun run prepare` (auto on `bun install`) |
 
 Don't run `npm run build` / `tsc` manually — the harness runs builds automatically.
+
+## Editor settings
+
+- Workspace editor config lives in `.vscode/settings.json` (see Hard Rules — don't fork it into `.cursor/`).
+- The `oxc-vscode` extension only contributes `oxc.enable`, `oxc.lint.*`, `oxc.fmt.*`, `oxc.path.*`, `oxc.configPath`, `oxc.fixKind`, and `oxc.trace.server`. Keys like `oxc.codeAction.*`, `oxc.options`, and `oxc.validate` are ESLint carryover — they produce "Unknown Configuration Setting" warnings and do nothing. Editor-side keys (`editor.defaultFormatter: "oxc.oxc-vscode"`, `source.format.oxc`, `source.fixAll.oxc`) are valid VS Code keys, not extension config, so they're fine.
 
 ## Editing the lint/format configs
 
@@ -121,6 +127,11 @@ If a file you touched still has lint errors after autofix, fix them in the same 
 ### CI expectation
 
 Any CI added later MUST run, in order: `bun run format:check`, `bun run lint`, `bun run typecheck`, then build. Failing any step fails the build. Mirror lefthook so local and CI agree.
+
+### Chromatic
+
+- Visual regression runs on `pull_request` only — **never** `on: push`. The workflow at `.github/workflows/chromatic.yml` uses `types: [opened, synchronize, reopened, ready_for_review]`, a `paths:` filter (`src/**`, `.storybook/**`, `chromatic.config.json`, `package.json`, `bun.lock`, the workflow file itself), and a job-level `if: github.event.pull_request.draft == false`. Don't reintroduce a push trigger or remove the draft gate.
+- `CHROMATIC_PROJECT_TOKEN` is read from env: CI gets it via `${{ secrets.CHROMATIC_PROJECT_TOKEN }}` in the workflow, the local `chromatic` script picks it up from the shell. Never hard-code the token in `package.json`, and never use `${{ secrets.X }}` syntax outside workflow files — it only interpolates inside GitHub Actions.
 
 ## Cursor Cloud specific instructions
 

--- a/src/components/portfolio/contact-form.tsx
+++ b/src/components/portfolio/contact-form.tsx
@@ -25,11 +25,7 @@ type Errors = Partial<Record<"name" | "email" | "message", string>>
 // Bots typically submit forms in well under a second.
 const MIN_SUBMIT_MS = 1500
 
-export function ContactForm({
-  initialStatus,
-}: {
-  initialStatus?: "ok" | "error" | "invalid"
-}) {
+export function ContactForm({ initialStatus }: { initialStatus?: "ok" | "error" | "invalid" }) {
   const [values, setValues] = useState({ name: "", email: "", message: "" })
   const [website, setWebsite] = useState("") // honeypot — must stay empty
   const [errors, setErrors] = useState<Errors>({})
@@ -248,7 +244,7 @@ export function ContactForm({
       <button
         type="submit"
         disabled={status === "submitting"}
-        className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-5 py-3 text-sm font-semibold text-primary-foreground shadow-[var(--glow-primary)] transition-transform hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:translate-y-0"
+        className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-5 py-3 text-sm font-semibold text-primary-foreground shadow-(--glow-primary) transition-transform hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:translate-y-0"
       >
         {status === "submitting" ? (
           <>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly repo hygiene and documentation, but it also changes a Tailwind class string in the contact form which could affect styling if the new `shadow-(--glow-primary)` syntax isn’t supported by the configured tooling.
> 
> **Overview**
> Removes the unused `.cursor/settings.json` and updates `AGENTS.md` with explicit guidance on where editor settings belong, which `oxc-vscode` keys are valid, and adds *Chromatic workflow* guardrails.
> 
> Also makes a small cleanup in `ContactForm` and updates the submit button’s `className`, including changing the shadow utility from `shadow-[var(--glow-primary)]` to `shadow-(--glow-primary)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88dabab5c1a0df10d4d2c54984209f5a52edddb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->