### PR TITLE
Add supergoal plugin config and ignore its run artifacts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "supergoal": {
+      "source": {
+        "source": "github",
+        "repo": "robzilla1738/supergoal"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "supergoal@supergoal": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,9 @@ supabase/exports/
 .kombai
 .omc
 .omc/*
-.claude
 .claude/*
+!.claude/settings.json
+.supergoal/
 .design-sync/sb-reference/
 .design-sync/learnings/
 .design-sync/.cache/


### PR DESCRIPTION
## Summary

Makes the [supergoal](https://github.com/robzilla1738/supergoal) plugin (deep planning + autonomous `/goal`-driven execution) persist across Claude Code sessions on this repo, per explicit request.

## Changes

- **`.claude/settings.json`** (new) — registers the supergoal marketplace (`github: robzilla1738/supergoal`) via `extraKnownMarketplaces` and enables `supergoal@supergoal`, so the `/supergoal` skill loads automatically in future sessions
- **`.gitignore`** — narrows `.claude` / `.claude/*` to `.claude/*` with a `!.claude/settings.json` exception (everything else under `.claude/` stays ignored), and adds `.supergoal/` so the run directories the skill creates during execution can't be accidentally committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g9FhRtJDy4HJPMenmTXDa

---
_Generated by [Claude Code](https://claude.ai/code/session_015g9FhRtJDy4HJPMenmTXDa)_